### PR TITLE
Update developer ID

### DIFF
--- a/data/dev.bragefuglseth.Fretboard.metainfo.xml.in.in
+++ b/data/dev.bragefuglseth.Fretboard.metainfo.xml.in.in
@@ -6,7 +6,7 @@
   <project_license>GPL-3.0-or-later</project_license>
   <name>Fretboard</name>
   <summary>Look up guitar chords</summary>
-  <developer id="bragefuglseth.dev">
+  <developer id="dev.bragefuglseth">
     <name translatable="no">Brage Fuglseth</name>
   </developer>
   <description>


### PR DESCRIPTION
Appstream decided to use reverse DNS for developer IDs.

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer