### PR TITLE
Adds the name of the string note to the open string tooltips.

### DIFF
--- a/src/chord_diagram.rs
+++ b/src/chord_diagram.rs
@@ -418,3 +418,10 @@ fn note_name(input: usize) -> &'static str {
         _ => unreachable!("root note above 11"),
     }
 }
+
+/// Returns the name of the note at `string_number`, where
+/// `string_number` follows the typical numbering of strings in
+/// a guitar, i.e. 1 being high E, up to 6 being the low E string.
+pub fn open_string_note_name(string_number: usize) -> &'static str {
+    note_name(NOTE_OFFSETS[6 - string_number])
+}

--- a/src/chord_diagram_top_toggle.rs
+++ b/src/chord_diagram_top_toggle.rs
@@ -4,6 +4,8 @@ use gtk::glib;
 use gtk::prelude::*;
 use std::cell::Cell;
 
+use crate::chord_diagram::open_string_note_name;
+
 #[derive(Default, Clone, Copy, Debug)]
 pub enum TopToggleState {
     #[default]
@@ -156,8 +158,12 @@ impl FretboardChordDiagramTopToggle {
         let tooltip_text = match imp.state.get() {
             TopToggleState::Off => gettext("Not Open"),
             TopToggleState::Muted => gettext("Muted"),
-            // translators: this is an adjective, not a verb
-            TopToggleState::Open => gettext("Open"),
+            TopToggleState::Open => format!(
+                "{} ({})",
+                // translators: this is an adjective, not a verb
+                gettext("Open"),
+                open_string_note_name(self.imp().number.get()),
+            ),
         };
 
         let n = imp.number.get();


### PR DESCRIPTION
This change adds the name of the note in the tooltip, as in 
![image](https://github.com/bragefuglseth/fretboard/assets/2386824/f0b0913f-379c-4ab8-ba1c-cd4a8e421169).

This makes it easier to understand what is going on with open strings.

Notes about the change:
- Gets around the localization problem by putting the name of the note between round parenthesis
- Exposes a `open_string_note_name` helper function from `chord_diagram`; this is because of where the needed data (note names and string notes) are. However create an horizontal dependency between `chord_diagram` and `chord_diagram_top_toggle.rs`. I can move things if this smells too bad.

Final closure: this is of course an unsolicited change... if you think the product is better without, feel free to reject.
