### PR TITLE
Adds the name of the string note to the open string tooltips (fixed)

### DIFF
--- a/src/chord_diagram.rs
+++ b/src/chord_diagram.rs
@@ -121,7 +121,8 @@ mod imp {
 
             // Setup top toggles
             for i in 0..STRINGS {
-                let top_toggle = FretboardChordDiagramTopToggle::new(STRINGS - i);
+                let top_toggle =
+                    FretboardChordDiagramTopToggle::new(STRINGS - i, note_name(NOTE_OFFSETS[i]));
                 top_toggle
                     .button()
                     .connect_clicked(glib::clone!(@weak obj => move |_| {
@@ -316,6 +317,8 @@ impl FretboardChordDiagram {
             }
 
             let offset = NOTE_OFFSETS.get(i).unwrap();
+            top_toggle.set_note_name(note_name(*offset));
+
             for (num, toggle) in toggles.get(string).unwrap().iter().enumerate() {
                 toggle.set_tooltip_text(Some(note_name(
                     offset + num + self.neck_position() as usize,


### PR DESCRIPTION
This change adds the name of the note in the tooltip, as in 
![image](https://github.com/bragefuglseth/fretboard/assets/2386824/f0b0913f-379c-4ab8-ba1c-cd4a8e421169).

This makes it easier to understand what is going on with open strings.

Notes about the change:
- Gets around the localization problem by putting the name of the note between round parenthesis
- Works with both left handed and right handed layouts (sorry for the bug and noise in #48 - I feared it could accidentally be merged so I yanked it.
- Much cleaner than before, now the logic is driven entirely by `chord_diagram` that updates the `note_name` in the top toggle.

Final closure: this is of course an unsolicited change... if you think the product is better without, feel free to reject.