### PR TITLE
build: Use Flathub's fork of the Flatpak action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       image: bilelmoussaoui/flatpak-github-actions:gnome-nightly
       options: --privileged
     steps:
-    - uses: actions/checkout@v3
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
+    - uses: actions/checkout@v4
+    - uses: flathub-infra/flatpak-github-actions/flatpak-builder@master
       with:
         bundle: fretboard.flatpak
         manifest-path: build-aux/dev.bragefuglseth.Fretboard.Devel.json

--- a/build-aux/dev.bragefuglseth.Fretboard.Devel.json
+++ b/build-aux/dev.bragefuglseth.Fretboard.Devel.json
@@ -39,7 +39,7 @@
 	    {
 	      "type": "git",
 	      "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-	      "tag": "v0.14.0"
+	      "tag": "v0.16.0"
 	    }
 	  ]
 	},


### PR DESCRIPTION
This should make CI work again, at least it did for Keypunch.