### PR TITLE
fix: Typo

### DIFF
--- a/data/dev.bragefuglseth.Fretboard.gschema.xml
+++ b/data/dev.bragefuglseth.Fretboard.gschema.xml
@@ -13,7 +13,7 @@
 	  <key name="handedness" type="s">
 			<default>'right-handed'</default>
 	    <!-- translators: "right-handed" and "left-handed" are enum values, and should not be translated -->
-	    <description>Can be either "right-handed"" or "left-handed".</description>
+	    <description>Can be either "right-handed" or "left-handed".</description>
 		</key>
 	</schema>
 </schemalist>


### PR DESCRIPTION
Since this edits a translatable string, you might want to hold off merging this before the next release. This would make all translations `fuzzy`