### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/dev.bragefuglseth.Fretboard.desktop.in.in
+++ b/data/dev.bragefuglseth.Fretboard.desktop.in.in
@@ -8,5 +8,6 @@ Type=Application
 Categories=Education;GTK;GNOME
 Keywords=guitar;chords
 StartupNotify=true
+DBusActivatable=true
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;

--- a/data/dev.bragefuglseth.Fretboard.service.in
+++ b/data/dev.bragefuglseth.Fretboard.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=@app-id@
+Exec=@bindir@/fretboard --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -60,4 +60,14 @@ if compile_schemas.found()
     args: ['--strict', '--dry-run', meson.current_source_dir()])
 endif
 
+service_conf = configuration_data()
+service_conf.set('app-id', app_id)
+service_conf.set('bindir', bindir)
+configure_file(
+  input: '@0@.service.in'.format(base_id),
+  output: '@0@.service'.format(app_id),
+  configuration: service_conf,
+  install_dir: datadir / 'dbus-1' / 'services'
+)
+
 subdir('icons')

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,7 @@ dependency('gtk4', version: '>= 4.10.1')
 dependency('libadwaita-1', version: '>= 1.5.alpha')
 
 prefix = get_option('prefix')
+bindir = prefix / get_option('bindir')
 localedir = prefix / get_option('localedir')
 datadir = prefix / get_option('datadir')
 pkgdatadir = datadir / meson.project_name()


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html