### PR TITLE
Add option to show note names on fretboard

### DIFF
--- a/data/dev.bragefuglseth.Fretboard.gschema.xml
+++ b/data/dev.bragefuglseth.Fretboard.gschema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="fretboard">
 	<schema id="dev.bragefuglseth.Fretboard" path="/dev/bragefuglseth/Fretboard/">
-	  <key name="window-width" type="i">
+		<key name="window-width" type="i">
 			<default>550</default>
 		</key>
 		<key name="window-height" type="i">
@@ -10,10 +10,15 @@
 		<key name="is-maximized" type="b">
 			<default>false</default>
 		</key>
-	  <key name="handedness" type="s">
+		<key name="handedness" type="s">
 			<default>'right-handed'</default>
-	    <!-- translators: "right-handed" and "left-handed" are enum values, and should not be translated -->
-	    <description>Can be either “right-handed” or “left-handed”.</description>
+			<!-- translators: "right-handed" and "left-handed" are enum values, and should not be translated -->
+			<description>Can be either "right-handed" or "left-handed".</description>
+		</key>
+		<key name="show-chord-notes" type="b">
+			<default>false</default>
+			<summary>Show note names</summary>
+			<description>Whether to display note names on the fretboard markers.</description>
 		</key>
 	</schema>
 </schemalist>

--- a/data/resources/shortcuts-dialog.ui
+++ b/data/resources/shortcuts-dialog.ui
@@ -29,6 +29,12 @@
             <property name="action-name">win.focus-entry</property>
           </object>
         </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title" translatable="yes" context="shortcut dialog">Show Chord Notes</property>
+            <property name="action-name">win.show-chord-notes</property>
+          </object>
+        </child>
       </object>
     </child>
     <child>

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -23,8 +23,7 @@ chord-diagram-toggle button,
   transition-duration: 150ms;
 }
 
-chord-diagram-toggle button:checked,
-.fretboard-chord-diagram-top-toggle.show-notes button:checked {
+chord-diagram-toggle button:checked {
   background: var(--accent-bg-color);
 }
 
@@ -32,12 +31,11 @@ chord-diagram-toggle button:hover {
   background: rgba(153, 153, 153, 0.3);
 }
 
-chord-diagram-toggle button:checked:hover,
-.fretboard-chord-diagram-top-toggle.show-notes button:checked:hover {
+chord-diagram-toggle button:checked:hover {
   background: var(--accent-bg-color);
 }
 
-.fretboard-chord-diagram-top-toggle:not(.show-notes) button:checked {
+.fretboard-chord-diagram-top-toggle button:checked {
   background: transparent;
   box-shadow: none;
 }
@@ -54,6 +52,15 @@ chord-diagram-toggle button:checked:hover,
 
 .fretboard-chord-diagram-top-toggle button:hover {
   background: rgba(153, 153, 153, 0.3);
+}
+
+.fretboard-chord-diagram-top-toggle.show-notes button:checked {
+  background: var(--accent-bg-color);
+}
+
+.fretboard-chord-diagram-top-toggle.show-notes button:checked:hover {
+  background: var(--accent-bg-color);
+  background-image: linear-gradient(rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.15));
 }
 
 .fretboard-chord-name-entry entry {

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -16,13 +16,15 @@ barre-spin label {
   font-weight: bold;
 }
 
-chord-diagram-toggle button, .fretboard-chord-diagram-top-toggle button{
+chord-diagram-toggle button,
+.fretboard-chord-diagram-top-toggle button {
   border-radius: 50%;
   padding: 0;
   transition-duration: 150ms;
 }
 
-chord-diagram-toggle button:checked {
+chord-diagram-toggle button:checked,
+.fretboard-chord-diagram-top-toggle.show-notes button:checked {
   background: var(--accent-bg-color);
 }
 
@@ -30,20 +32,23 @@ chord-diagram-toggle button:hover {
   background: rgba(153, 153, 153, 0.3);
 }
 
-chord-diagram-toggle button:checked:hover {
+chord-diagram-toggle button:checked:hover,
+.fretboard-chord-diagram-top-toggle.show-notes button:checked:hover {
   background: var(--accent-bg-color);
 }
 
-.fretboard-chord-diagram-top-toggle button:checked{
+.fretboard-chord-diagram-top-toggle:not(.show-notes) button:checked {
   background: transparent;
   box-shadow: none;
 }
 
-.fretboard-chord-diagram-top-toggle, .fretboard-chord-diagram-top-toggle image {
+.fretboard-chord-diagram-top-toggle,
+.fretboard-chord-diagram-top-toggle image {
   color: rgba(153, 153, 153, 0.4);
 }
 
-.fretboard-chord-diagram-top-toggle.open, .fretboard-chord-diagram-top-toggle image.open {
+.fretboard-chord-diagram-top-toggle.open,
+.fretboard-chord-diagram-top-toggle image.open {
   color: var(--accent-bg-color);
 }
 
@@ -77,7 +82,7 @@ chord-diagram-toggle button:checked:hover {
 
 .fretboard-chord-preview-dot.active {
   background: var(--accent-bg-color);
-} 
+}
 
 .fretboard-chord-preview-button {
   padding: 16px 0;
@@ -86,4 +91,10 @@ chord-diagram-toggle button:checked:hover {
 
 .fretboard-chord-preview-button:hover {
   background-color: alpha(currentColor, 0.025);
+}
+
+chord-diagram-toggle label,
+.fretboard-chord-diagram-top-toggle.show-notes label {
+  font-weight: bold;
+  color: var(--accent-fg-color);
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -97,5 +97,6 @@ impl FretboardApplication {
         self.set_accels_for_action("win.more-variants", &["<Alt>Return"]);
         self.set_accels_for_action("win.bookmark-chord", &["<Ctrl>D"]);
         self.set_accels_for_action("win.bookmarks", &["<Ctrl><Alt>D"]);
+        self.set_accels_for_action("win.show-chord-notes", &["<Ctrl><Alt>C"]);
     }
 }

--- a/src/widgets/chord_diagram.rs
+++ b/src/widgets/chord_diagram.rs
@@ -57,6 +57,9 @@ mod imp {
 
         pub top_toggles: RefCell<Vec<FretboardChordDiagramTopToggle>>,
         pub toggles: RefCell<Vec<Vec<gtk::ToggleButton>>>,
+
+        #[property(get, set)]
+        pub show_chord_notes: Cell<bool>,
     }
 
     #[glib::object_subclass]
@@ -191,6 +194,15 @@ mod imp {
                 ),
             );
 
+            obj.connect_notify_local(Some("show-chord-notes"), move |diag, _| {
+                let show = diag.show_chord_notes();
+                for top_toggle in diag.imp().top_toggles.borrow().iter() {
+                    top_toggle.set_show_chord_notes(show);
+                }
+
+                diag.update_chord_notes();
+            });
+
             self.obj().update_visuals();
         }
 
@@ -264,6 +276,7 @@ impl FretboardChordDiagram {
         }
 
         self.imp().chord.set(chord);
+        self.update_chord_notes();
         self.update_barre_visuals();
     }
 
@@ -341,6 +354,24 @@ impl FretboardChordDiagram {
                 toggle.set_tooltip_text(Some(note_name(
                     offset + num + self.neck_position() as usize,
                 )));
+            }
+        }
+        self.update_chord_notes();
+    }
+
+    fn update_chord_notes(&self) {
+        let show = self.show_chord_notes();
+        let toggles = self.imp().toggles.borrow();
+
+        for string in 0..STRINGS {
+            for toggle in toggles.get(string).unwrap().iter() {
+                if toggle.is_active() && show {
+                    if let Some(name) = toggle.tooltip_text() {
+                        toggle.set_label(&name);
+                    }
+                } else {
+                    toggle.set_label("");
+                }
             }
         }
     }

--- a/src/widgets/chord_diagram_top_toggle.rs
+++ b/src/widgets/chord_diagram_top_toggle.rs
@@ -3,7 +3,7 @@ use gettextrs::gettext;
 use gtk::glib;
 use gtk::prelude::*;
 use i18n_format::i18n_fmt;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 
 #[derive(Default, Clone, Copy, Debug)]
 pub enum TopToggleState {
@@ -33,6 +33,9 @@ mod imp {
         pub state: Cell<TopToggleState>,
         pub number: Cell<usize>,
         pub note_name: Cell<&'static str>,
+
+        pub note_label: RefCell<Option<gtk::Label>>,
+        pub show_chord_notes: Cell<bool>,
     }
 
     #[glib::object_subclass]
@@ -64,6 +67,11 @@ mod imp {
 
             let obj = self.obj();
             obj.add_css_class("fretboard-chord-diagram-top-toggle");
+
+            let label = gtk::Label::new(None);
+            self.icon_stack.add_named(&label, Some("note_name"));
+            self.note_label.replace(Some(label));
+
             obj.setup_callbacks();
         }
     }
@@ -94,6 +102,11 @@ impl FretboardChordDiagramTopToggle {
         self.imp().button.get()
     }
 
+    pub fn set_show_chord_notes(&self, show: bool) {
+        self.imp().show_chord_notes.set(show);
+        self.update_icon();
+    }
+
     pub fn set_state(&self, state: TopToggleState) {
         let imp = self.imp();
 
@@ -116,6 +129,11 @@ impl FretboardChordDiagramTopToggle {
 
     pub fn set_note_name(&self, note_name: &'static str) {
         self.imp().note_name.set(note_name);
+
+        if let Some(label) = &*self.imp().note_label.borrow() {
+            label.set_label(note_name);
+        }
+
         self.update_tooltip();
     }
 
@@ -182,10 +200,25 @@ impl FretboardChordDiagramTopToggle {
     pub fn update_icon(&self) {
         let imp = self.imp();
 
+        let show_notes = imp.show_chord_notes.get();
+        let is_open = matches!(imp.state.get(), TopToggleState::Open);
+
+        if show_notes && is_open {
+            self.add_css_class("show-notes");
+        } else {
+            self.remove_css_class("show-notes");
+        }
+
         imp.icon_stack
             .set_visible_child_name(match imp.state.get() {
                 TopToggleState::Off => "off",
-                TopToggleState::Open => "open",
+                TopToggleState::Open => {
+                    if show_notes {
+                        "note_name"
+                    } else {
+                        "open"
+                    }
+                }
                 TopToggleState::Muted => "muted",
             });
 

--- a/src/widgets/window.blp
+++ b/src/widgets/window.blp
@@ -227,6 +227,13 @@ menu primary_menu {
 
   section {
     item {
+      label: _("Show chord notes");
+      action: "win.show-chord-notes";
+    }
+  }
+
+  section {
+    item {
       // translators: "Empty" is a verb
       label: _("_Empty Chord");
       action: "win.empty-chord";

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -31,7 +31,7 @@ use gtk::{gio, glib};
 use i18n_format::i18n_fmt;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::fs::File;
 use std::path::PathBuf;
 
@@ -96,6 +96,9 @@ mod imp {
         pub handedness: RefCell<String>,
 
         pub settings: OnceCell<gio::Settings>,
+
+        #[property(get, set)]
+        pub show_chord_notes: Cell<bool>,
     }
 
     #[glib::object_subclass]
@@ -106,6 +109,7 @@ mod imp {
 
         fn class_init(klass: &mut Self::Class) {
             klass.install_property_action("win.set-handedness", "handedness");
+            klass.install_property_action("win.show-chord-notes", "show-chord-notes");
 
             klass.install_action("win.empty-chord", None, move |win, _, _| {
                 win.empty_chord();
@@ -240,8 +244,18 @@ impl FretboardWindow {
                 });
         });
 
+        self.connect_notify_local(Some("show-chord-notes"), move |win, _| {
+            let imp = win.imp();
+            imp.chord_diagram
+                .set_show_chord_notes(win.show_chord_notes());
+        });
+
         self.settings()
             .bind("handedness", self, "handedness")
+            .build();
+
+        self.settings()
+            .bind("show-chord-notes", self, "show-chord-notes")
             .build();
 
         let chord_diagram = imp.chord_diagram.get();
@@ -659,7 +673,9 @@ impl FretboardWindow {
 
                     win.imp().chord_diagram.set_chord(chord);
                     win.imp().entry.overwrite_text(&prettify_chord_name(&name));
-                    win.imp().feedback_stack.set_visible_child_name("chord-actions");
+                    win.imp()
+                        .feedback_stack
+                        .set_visible_child_name("chord-actions");
                     win.refresh_star_toggle();
                     win.imp().navigation_stack.pop();
                 }


### PR DESCRIPTION
feature: Add option to show note names on fretboard

Adds a new toggleable setting that displays the calculated note names directly inside the fret markers on the interactive diagram.

- Adds a "Show chord notes" toggle to the primary menu.
- Persists the user's preference using GSettings.
- Includes a <Ctrl><Alt>C keyboard shortcut and help overlay entry.
- Updates CSS to seamlessly transition top string toggles between ring icons and solid blue note indicators.
<img width="457" height="539" alt="Screenshot from 2026-03-18 16-51-26" src="https://github.com/user-attachments/assets/f498492b-d3a9-402c-b30e-aece9f76a602" />
